### PR TITLE
Dockerfile update with moonlight-chrome-tizen repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN ./emsdk activate latest-fastcomp
 WORKDIR ../..
 
 # Build moonlight
-COPY --chown=moonlight . ./moonlight-chrome-tizen
+RUN git clone --recurse-submodules --depth 1 https://github.com/KyroFrCode/moonlight-chrome-tizen
 
 RUN cmake \
 	-DCMAKE_TOOLCHAIN_FILE=/home/moonlight/emscripten-release-bundle/emsdk/fastcomp/emscripten/cmake/Modules/Platform/Emscripten.cmake \


### PR DESCRIPTION
Adding the repo for [moonlight-chrome-tizen-docker](https://github.com/KyroFrCode/moonlight-chrome-tizen-docker) to avoid build errors